### PR TITLE
Switch timing mechanism from generic timer to RTC

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -89,15 +89,17 @@
 								<option id="gnu.c.compiler.option.preprocessor.preprocess.1306393576" name="Preprocess only (-E)" superClass="gnu.c.compiler.option.preprocessor.preprocess" useByScannerDiscovery="false"/>
 								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.2027597437" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1680838800" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
@@ -110,37 +112,35 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/frdmk64f_lwip_dhcp_bm/lwip/src/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
 								<option id="gnu.c.compiler.option.include.files.1838434674" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false"/>
@@ -182,15 +182,17 @@
 								<option id="com.crt.advproject.gas.arch.395510399" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm4" valueType="enumerated"/>
 								<option id="gnu.both.asm.option.flags.crt.1093761540" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.1683893902" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
@@ -203,37 +205,35 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/frdmk64f_lwip_dhcp_bm/lwip/src/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
 								<option id="gnu.both.asm.option.warnings.nowarn.1084259095" name="Suppress warnings (-W)" superClass="gnu.both.asm.option.warnings.nowarn"/>
@@ -373,9 +373,10 @@
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
-						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="lwip"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
 					</sourceEntries>
 				</configuration>
@@ -469,15 +470,17 @@
 								</option>
 								<option id="gnu.c.compiler.option.preprocessor.undef.symbol.1404966564" name="Undefined symbols (-U)" superClass="gnu.c.compiler.option.preprocessor.undef.symbol" useByScannerDiscovery="false"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.197462930" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
@@ -490,37 +493,35 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/frdmk64f_lwip_dhcp_bm/lwip/src/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
 								<option id="gnu.c.compiler.option.include.files.998124034" name="Include files (-include)" superClass="gnu.c.compiler.option.include.files" useByScannerDiscovery="false"/>
@@ -560,15 +561,17 @@
 								<option id="com.crt.advproject.gas.arch.926467368" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.cm4" valueType="enumerated"/>
 								<option id="gnu.both.asm.option.flags.crt.1354211066" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__REDLIB__" valueType="string"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.1911801331" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
@@ -581,37 +584,35 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/frdmk64f_lwip_dhcp_bm/lwip/src/apps}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/lists}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/CMSIS}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/drivers}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/uart}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/device}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/utilities}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/component/serial_manager}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/board}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port/arch}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/arpa}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/net}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/posix/sys}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/compat/stdc}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/priv}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/prot}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/netif/ppp/polarssl}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/port}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include/lwip/apps}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/lwip/src/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/}&quot;"/>
 								</option>
 								<option id="gnu.both.asm.option.warnings.nowarn.1472273174" name="Suppress warnings (-W)" superClass="gnu.both.asm.option.warnings.nowarn"/>
@@ -751,9 +752,10 @@
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="CMSIS"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="source"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="utilities"/>
-						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="device"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="drivers"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="board"/>
+						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="lwip"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="startup"/>
 					</sourceEntries>
 				</configuration>
@@ -784,7 +786,7 @@
 		<sdkName>SDK_2.x_FRDM-K64F</sdkName>
 		<sdkExample>frdmk64f_lwip_dhcp_bm</sdkExample>
 		<sdkVersion>2.7.0</sdkVersion>
-		<sdkComponents>driver.phyksz8081.MK64F12;platform.drivers.enet.MK64F12;platform.drivers.common.MK64F12;platform.drivers.clock.MK64F12;device.MK64F12_CMSIS.MK64F12;platform.Include_core_cm4.MK64F12;platform.Include_common.MK64F12;platform.Include_dsp.MK64F12;platform.drivers.port.MK64F12;middleware.lwip.MK64F12;middleware.lwip.default.MK64F12;middleware.lwip.enet_ethernetif_kinetis.MK64F12;middleware.lwip.enet_ethernetif.MK64F12;platform.drivers.flash.MK64F12;platform.drivers.gpio.MK64F12;utility.debug_console.MK64F12;component.serial_manager.MK64F12;component.lists.MK64F12;platform.drivers.uart.MK64F12;platform.drivers.smc.MK64F12;component.uart_adapter.MK64F12;component.serial_manager_uart.MK64F12;device.MK64F12_startup.MK64F12;platform.utilities.assert.MK64F12;platform.utilities.misc_utilities.MK64F12;frdmk64f_lwip_dhcp_bm;middleware.lwip.template_application.MK64F12;middleware.baremetal.MK64F12;middleware.lwip.apps.sntp.MK64F12;platform.drivers.dspi.MK64F12;</sdkComponents>
+		<sdkComponents>driver.phyksz8081.MK64F12;platform.drivers.enet.MK64F12;platform.drivers.common.MK64F12;platform.drivers.clock.MK64F12;device.MK64F12_CMSIS.MK64F12;platform.Include_core_cm4.MK64F12;platform.Include_common.MK64F12;platform.Include_dsp.MK64F12;platform.drivers.port.MK64F12;middleware.lwip.MK64F12;middleware.lwip.default.MK64F12;middleware.lwip.enet_ethernetif_kinetis.MK64F12;middleware.lwip.enet_ethernetif.MK64F12;platform.drivers.flash.MK64F12;platform.drivers.gpio.MK64F12;utility.debug_console.MK64F12;component.serial_manager.MK64F12;component.lists.MK64F12;platform.drivers.uart.MK64F12;platform.drivers.smc.MK64F12;component.uart_adapter.MK64F12;component.serial_manager_uart.MK64F12;device.MK64F12_startup.MK64F12;platform.utilities.assert.MK64F12;platform.utilities.misc_utilities.MK64F12;frdmk64f_lwip_dhcp_bm;middleware.lwip.template_application.MK64F12;middleware.baremetal.MK64F12;middleware.lwip.apps.sntp.MK64F12;platform.drivers.dspi.MK64F12;platform.drivers.rtc.MK64F12;</sdkComponents>
 		<boardId>frdmk64f</boardId>
 		<package>MK64FN1M0VLL12</package>
 		<core>cm4</core>

--- a/.settings/org.eclipse.cdt.core.prefs
+++ b/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+environment/project/com.crt.advproject.config.exe.debug.1435374920/TZ/delimiter=\:
+environment/project/com.crt.advproject.config.exe.debug.1435374920/TZ/operation=append
+environment/project/com.crt.advproject.config.exe.debug.1435374920/TZ/value=EST+5EDT,M3.2.0/2,M11.1.0/2
+environment/project/com.crt.advproject.config.exe.debug.1435374920/append=true
+environment/project/com.crt.advproject.config.exe.debug.1435374920/appendContributed=true
+environment/project/com.crt.advproject.config.exe.release.2097082186/TZ/delimiter=\:
+environment/project/com.crt.advproject.config.exe.release.2097082186/TZ/operation=append
+environment/project/com.crt.advproject.config.exe.release.2097082186/TZ/value=EST+5EDT,M3.2.0/2,M11.1.0/2
+environment/project/com.crt.advproject.config.exe.release.2097082186/append=true
+environment/project/com.crt.advproject.config.exe.release.2097082186/appendContributed=true

--- a/drivers/fsl_rtc.c
+++ b/drivers/fsl_rtc.c
@@ -1,0 +1,791 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_rtc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.rtc"
+#endif
+
+#define SECONDS_IN_A_DAY (86400U)
+#define SECONDS_IN_A_HOUR (3600U)
+#define SECONDS_IN_A_MINUTE (60U)
+#define DAYS_IN_A_YEAR (365U)
+#define YEAR_RANGE_START (1970U)
+#define YEAR_RANGE_END (2099U)
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+/*!
+ * @brief Checks whether the date and time passed in is valid
+ *
+ * @param datetime Pointer to structure where the date and time details are stored
+ *
+ * @return Returns false if the date & time details are out of range; true if in range
+ */
+static bool RTC_CheckDatetimeFormat(const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Converts time data from datetime to seconds
+ *
+ * @param datetime Pointer to datetime structure where the date and time details are stored
+ *
+ * @return The result of the conversion in seconds
+ */
+static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Converts time data from seconds to a datetime structure
+ *
+ * @param seconds  Seconds value that needs to be converted to datetime format
+ * @param datetime Pointer to the datetime structure where the result of the conversion is stored
+ */
+static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime);
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+static bool RTC_CheckDatetimeFormat(const rtc_datetime_t *datetime)
+{
+    assert(NULL != datetime);
+
+    /* Table of days in a month for a non leap year. First entry in the table is not used,
+     * valid months start from 1
+     */
+    uint8_t daysPerMonth[] = {0U, 31U, 28U, 31U, 30U, 31U, 30U, 31U, 31U, 30U, 31U, 30U, 31U};
+
+    /* Check year, month, hour, minute, seconds */
+    if ((datetime->year < YEAR_RANGE_START) || (datetime->year > YEAR_RANGE_END) || (datetime->month > 12U) ||
+        (datetime->month < 1U) || (datetime->hour >= 24U) || (datetime->minute >= 60U) || (datetime->second >= 60U))
+    {
+        /* If not correct then error*/
+        return false;
+    }
+
+    /* Adjust the days in February for a leap year */
+    if ((((datetime->year & 3U) == 0U) && (datetime->year % 100U != 0U)) || (datetime->year % 400U == 0U))
+    {
+        daysPerMonth[2] = 29U;
+    }
+
+    /* Check the validity of the day */
+    if ((datetime->day > daysPerMonth[datetime->month]) || (datetime->day < 1U))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime)
+{
+    assert(NULL != datetime);
+
+    /* Number of days from begin of the non Leap-year*/
+    /* Number of days from begin of the non Leap-year*/
+    uint16_t monthDays[] = {0U, 0U, 31U, 59U, 90U, 120U, 151U, 181U, 212U, 243U, 273U, 304U, 334U};
+    uint32_t seconds;
+
+    /* Compute number of days from 1970 till given year*/
+    seconds = ((uint32_t)datetime->year - 1970U) * DAYS_IN_A_YEAR;
+    /* Add leap year days */
+    seconds += (((uint32_t)datetime->year / 4U) - (1970U / 4U));
+    /* Add number of days till given month*/
+    seconds += monthDays[datetime->month];
+    /* Add days in given month. We subtract the current day as it is
+     * represented in the hours, minutes and seconds field*/
+    seconds += ((uint32_t)datetime->day - 1U);
+    /* For leap year if month less than or equal to Febraury, decrement day counter*/
+    if ((0U == (datetime->year & 3U)) && (datetime->month <= 2U))
+    {
+        seconds--;
+    }
+
+    seconds = (seconds * SECONDS_IN_A_DAY) + ((uint32_t)datetime->hour * SECONDS_IN_A_HOUR) +
+              ((uint32_t)datetime->minute * SECONDS_IN_A_MINUTE) + datetime->second;
+
+    return seconds;
+}
+
+static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime)
+{
+    assert(NULL != datetime);
+
+    uint32_t x;
+    uint32_t secondsRemaining, days;
+    uint16_t daysInYear;
+    /* Table of days in a month for a non leap year. First entry in the table is not used,
+     * valid months start from 1
+     */
+    uint8_t daysPerMonth[] = {0U, 31U, 28U, 31U, 30U, 31U, 30U, 31U, 31U, 30U, 31U, 30U, 31U};
+
+    /* Start with the seconds value that is passed in to be converted to date time format */
+    secondsRemaining = seconds;
+
+    /* Calcuate the number of days, we add 1 for the current day which is represented in the
+     * hours and seconds field
+     */
+    days = secondsRemaining / SECONDS_IN_A_DAY + 1U;
+
+    /* Update seconds left*/
+    secondsRemaining = secondsRemaining % SECONDS_IN_A_DAY;
+
+    /* Calculate the datetime hour, minute and second fields */
+    datetime->hour   = (uint8_t)(secondsRemaining / SECONDS_IN_A_HOUR);
+    secondsRemaining = secondsRemaining % SECONDS_IN_A_HOUR;
+    datetime->minute = (uint8_t)(secondsRemaining / 60U);
+    datetime->second = (uint8_t)(secondsRemaining % SECONDS_IN_A_MINUTE);
+
+    /* Calculate year */
+    daysInYear     = DAYS_IN_A_YEAR;
+    datetime->year = YEAR_RANGE_START;
+    while (days > daysInYear)
+    {
+        /* Decrease day count by a year and increment year by 1 */
+        days -= daysInYear;
+        datetime->year++;
+
+        /* Adjust the number of days for a leap year */
+        if (0U != (datetime->year & 3U))
+        {
+            daysInYear = DAYS_IN_A_YEAR;
+        }
+        else
+        {
+            daysInYear = DAYS_IN_A_YEAR + 1U;
+        }
+    }
+
+    /* Adjust the days in February for a leap year */
+    if (0U == (datetime->year & 3U))
+    {
+        daysPerMonth[2] = 29U;
+    }
+
+    for (x = 1U; x <= 12U; x++)
+    {
+        if (days <= daysPerMonth[x])
+        {
+            datetime->month = (uint8_t)x;
+            break;
+        }
+        else
+        {
+            days -= daysPerMonth[x];
+        }
+    }
+
+    datetime->day = (uint8_t)days;
+}
+
+/*!
+ * brief Ungates the RTC clock and configures the peripheral for basic operation.
+ *
+ * This function issues a software reset if the timer invalid flag is set.
+ *
+ * note This API should be called at the beginning of the application using the RTC driver.
+ *
+ * param base   RTC peripheral base address
+ * param config Pointer to the user's RTC configuration structure.
+ */
+void RTC_Init(RTC_Type *base, const rtc_config_t *config)
+{
+    assert(NULL != config);
+
+    uint32_t reg;
+
+#if defined(RTC_CLOCKS)
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+#endif /* RTC_CLOCKS */
+
+    /* Issue a software reset if timer is invalid */
+    if ((uint32_t)kRTC_TimeInvalidFlag == (RTC_GetStatusFlags(base) & (uint32_t)kRTC_TimeInvalidFlag))
+    {
+        RTC_Reset(base);
+    }
+
+    reg = base->CR;
+/* Setup the update mode and supervisor access mode */
+#if !(defined(FSL_FEATURE_RTC_HAS_NO_CR_OSCE) && FSL_FEATURE_RTC_HAS_NO_CR_OSCE)
+    reg &= ~(RTC_CR_UM_MASK | RTC_CR_SUP_MASK);
+    reg |= RTC_CR_UM(config->updateMode) | RTC_CR_SUP(config->supervisorAccess);
+#else
+    reg &= ~RTC_CR_UM_MASK;
+    reg |= RTC_CR_UM(config->updateMode);
+#endif
+
+#if defined(FSL_FEATURE_RTC_HAS_WAKEUP_PIN_SELECTION) && FSL_FEATURE_RTC_HAS_WAKEUP_PIN_SELECTION
+    /* Setup the wakeup pin select */
+    reg &= ~(RTC_CR_WPS_MASK);
+    reg |= RTC_CR_WPS(config->wakeupSelect);
+#endif /* FSL_FEATURE_RTC_HAS_WAKEUP_PIN */
+    base->CR = reg;
+
+    /* Configure the RTC time compensation register */
+    base->TCR = (RTC_TCR_CIR(config->compensationInterval) | RTC_TCR_TCR(config->compensationTime));
+
+#if defined(FSL_FEATURE_RTC_HAS_TSIC) && FSL_FEATURE_RTC_HAS_TSIC
+    /* Configure RTC timer seconds interrupt to be generated once per second */
+    base->IER &= ~(RTC_IER_TSIC_MASK | RTC_IER_TSIE_MASK);
+#endif
+}
+
+/*!
+ * brief Fills in the RTC config struct with the default settings.
+ *
+ * The default values are as follows.
+ * code
+ *    config->wakeupSelect = false;
+ *    config->updateMode = false;
+ *    config->supervisorAccess = false;
+ *    config->compensationInterval = 0;
+ *    config->compensationTime = 0;
+ * endcode
+ * param config Pointer to the user's RTC configuration structure.
+ */
+void RTC_GetDefaultConfig(rtc_config_t *config)
+{
+    assert(NULL != config);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(config, 0, sizeof(*config));
+
+    /* Wakeup pin will assert if the RTC interrupt asserts or if the wakeup pin is turned on */
+    config->wakeupSelect = false;
+    /* Registers cannot be written when locked */
+    config->updateMode = false;
+    /* Non-supervisor mode write accesses are not supported and will generate a bus error */
+    config->supervisorAccess = false;
+    /* Compensation interval used by the crystal compensation logic */
+    config->compensationInterval = 0;
+    /* Compensation time used by the crystal compensation logic */
+    config->compensationTime = 0;
+}
+
+/*!
+ * brief Sets the RTC date and time according to the given time structure.
+ *
+ * The RTC counter must be stopped prior to calling this function because writes to the RTC
+ * seconds register fail if the RTC counter is running.
+ *
+ * param base     RTC peripheral base address
+ * param datetime Pointer to the structure where the date and time details are stored.
+ *
+ * return kStatus_Success: Success in setting the time and starting the RTC
+ *         kStatus_InvalidArgument: Error because the datetime format is incorrect
+ */
+status_t RTC_SetDatetime(RTC_Type *base, const rtc_datetime_t *datetime)
+{
+    assert(NULL != datetime);
+
+    /* Return error if the time provided is not valid */
+    if (!(RTC_CheckDatetimeFormat(datetime)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    /* Set time in seconds */
+    base->TSR = RTC_ConvertDatetimeToSeconds(datetime);
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Gets the RTC time and stores it in the given time structure.
+ *
+ * param base     RTC peripheral base address
+ * param datetime Pointer to the structure where the date and time details are stored.
+ */
+void RTC_GetDatetime(RTC_Type *base, rtc_datetime_t *datetime)
+{
+    assert(NULL != datetime);
+
+    uint32_t seconds = 0;
+
+    seconds = base->TSR;
+    RTC_ConvertSecondsToDatetime(seconds, datetime);
+}
+
+/*!
+ * brief Sets the RTC alarm time.
+ *
+ * The function checks whether the specified alarm time is greater than the present
+ * time. If not, the function does not set the alarm and returns an error.
+ *
+ * param base      RTC peripheral base address
+ * param alarmTime Pointer to the structure where the alarm time is stored.
+ *
+ * return kStatus_Success: success in setting the RTC alarm
+ *         kStatus_InvalidArgument: Error because the alarm datetime format is incorrect
+ *         kStatus_Fail: Error because the alarm time has already passed
+ */
+status_t RTC_SetAlarm(RTC_Type *base, const rtc_datetime_t *alarmTime)
+{
+    assert(NULL != alarmTime);
+
+    uint32_t alarmSeconds = 0;
+    uint32_t currSeconds  = 0;
+
+    /* Return error if the alarm time provided is not valid */
+    if (!(RTC_CheckDatetimeFormat(alarmTime)))
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    alarmSeconds = RTC_ConvertDatetimeToSeconds(alarmTime);
+
+    /* Get the current time */
+    currSeconds = base->TSR;
+
+    /* Return error if the alarm time has passed */
+    if (alarmSeconds < currSeconds)
+    {
+        return kStatus_Fail;
+    }
+
+    /* Set alarm in seconds*/
+    base->TAR = alarmSeconds;
+
+    return kStatus_Success;
+}
+
+/*!
+ * brief Returns the RTC alarm time.
+ *
+ * param base     RTC peripheral base address
+ * param datetime Pointer to the structure where the alarm date and time details are stored.
+ */
+void RTC_GetAlarm(RTC_Type *base, rtc_datetime_t *datetime)
+{
+    assert(NULL != datetime);
+
+    uint32_t alarmSeconds = 0;
+
+    /* Get alarm in seconds  */
+    alarmSeconds = base->TAR;
+
+    RTC_ConvertSecondsToDatetime(alarmSeconds, datetime);
+}
+
+/*!
+ * brief Enables the selected RTC interrupts.
+ *
+ * param base RTC peripheral base address
+ * param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::rtc_interrupt_enable_t
+ */
+void RTC_EnableInterrupts(RTC_Type *base, uint32_t mask)
+{
+    uint32_t tmp32 = 0U;
+
+    /* RTC_IER */
+    if (0U != ((uint32_t)kRTC_TimeInvalidInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TIIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_TimeOverflowInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TOIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_AlarmInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TAIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_SecondsInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TSIE_MASK;
+    }
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+    if (0U != ((uint32_t)kRTC_MonotonicOverflowInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_MOIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+    base->IER |= tmp32;
+
+#if (defined(FSL_FEATURE_RTC_HAS_TIR) && FSL_FEATURE_RTC_HAS_TIR)
+    tmp32 = 0U;
+
+    /* RTC_TIR */
+    if (0U != ((uint32_t)kRTC_TestModeInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_TMIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_FlashSecurityInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_FSIE_MASK;
+    }
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_TPIE) && FSL_FEATURE_RTC_HAS_TIR_TPIE)
+    if (0U != ((uint32_t)kRTC_TamperPinInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_TPIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_TPIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_SIE) && FSL_FEATURE_RTC_HAS_TIR_SIE)
+    if (0U != ((uint32_t)kRTC_SecurityModuleInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_SIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_SIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_LCIE) && FSL_FEATURE_RTC_HAS_TIR_LCIE)
+    if (0U != ((uint32_t)kRTC_LossOfClockInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_LCIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_LCIE */
+    base->TIR |= tmp32;
+#endif /* FSL_FEATURE_RTC_HAS_TIR */
+}
+
+/*!
+ * brief Disables the selected RTC interrupts.
+ *
+ * param base RTC peripheral base address
+ * param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::rtc_interrupt_enable_t
+ */
+void RTC_DisableInterrupts(RTC_Type *base, uint32_t mask)
+{
+    uint32_t tmp32 = 0U;
+
+    /* RTC_IER */
+    if (0U != ((uint32_t)kRTC_TimeInvalidInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TIIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_TimeOverflowInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TOIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_AlarmInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TAIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_SecondsInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_TSIE_MASK;
+    }
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+    if (0U != ((uint32_t)kRTC_MonotonicOverflowInterruptEnable & mask))
+    {
+        tmp32 |= RTC_IER_MOIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+    base->IER &= (uint32_t)(~tmp32);
+
+#if (defined(FSL_FEATURE_RTC_HAS_TIR) && FSL_FEATURE_RTC_HAS_TIR)
+    tmp32 = 0U;
+
+    /* RTC_TIR */
+    if (0U != ((uint32_t)kRTC_TestModeInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_TMIE_MASK;
+    }
+    if (0U != ((uint32_t)kRTC_FlashSecurityInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_FSIE_MASK;
+    }
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_TPIE) && FSL_FEATURE_RTC_HAS_TIR_TPIE)
+    if (0U != ((uint32_t)kRTC_TamperPinInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_TPIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_TPIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_SIE) && FSL_FEATURE_RTC_HAS_TIR_SIE)
+    if (0U != ((uint32_t)kRTC_SecurityModuleInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_SIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_SIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_LCIE) && FSL_FEATURE_RTC_HAS_TIR_LCIE)
+    if (0U != ((uint32_t)kRTC_LossOfClockInterruptEnable & mask))
+    {
+        tmp32 |= RTC_TIR_LCIE_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_LCIE */
+    base->TIR &= (uint32_t)(~tmp32);
+#endif /* FSL_FEATURE_RTC_HAS_TIR */
+}
+
+/*!
+ * brief Gets the enabled RTC interrupts.
+ *
+ * param base RTC peripheral base address
+ *
+ * return The enabled interrupts. This is the logical OR of members of the
+ *         enumeration ::rtc_interrupt_enable_t
+ */
+uint32_t RTC_GetEnabledInterrupts(RTC_Type *base)
+{
+    uint32_t tmp32 = 0U;
+
+    /* RTC_IER */
+    if (0U != (RTC_IER_TIIE_MASK & base->IER))
+    {
+        tmp32 |= (uint32_t)kRTC_TimeInvalidInterruptEnable;
+    }
+    if (0U != (RTC_IER_TOIE_MASK & base->IER))
+    {
+        tmp32 |= (uint32_t)kRTC_TimeOverflowInterruptEnable;
+    }
+    if (0U != (RTC_IER_TAIE_MASK & base->IER))
+    {
+        tmp32 |= (uint32_t)kRTC_AlarmInterruptEnable;
+    }
+    if (0U != (RTC_IER_TSIE_MASK & base->IER))
+    {
+        tmp32 |= (uint32_t)kRTC_SecondsInterruptEnable;
+    }
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+    if (0U != (RTC_IER_MOIE_MASK & base->IER))
+    {
+        tmp32 |= (uint32_t)kRTC_MonotonicOverflowInterruptEnable;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+
+#if (defined(FSL_FEATURE_RTC_HAS_TIR) && FSL_FEATURE_RTC_HAS_TIR)
+    /* RTC_TIR */
+    if (0U != (RTC_TIR_TMIE_MASK & base->TIR))
+    {
+        tmp32 |= (uint32_t)kRTC_TestModeInterruptEnable;
+    }
+    if (0U != (RTC_TIR_FSIE_MASK & base->TIR))
+    {
+        tmp32 |= (uint32_t)kRTC_FlashSecurityInterruptEnable;
+    }
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_TPIE) && FSL_FEATURE_RTC_HAS_TIR_TPIE)
+    if (0U != (RTC_TIR_TPIE_MASK & base->TIR))
+    {
+        tmp32 |= (uint32_t)kRTC_TamperPinInterruptEnable;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_TPIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_SIE) && FSL_FEATURE_RTC_HAS_TIR_SIE)
+    if (0U != (RTC_TIR_SIE_MASK & base->TIR))
+    {
+        tmp32 |= (uint32_t)kRTC_SecurityModuleInterruptEnable;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_SIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_LCIE) && FSL_FEATURE_RTC_HAS_TIR_LCIE)
+    if (0U != (RTC_TIR_LCIE_MASK & base->TIR))
+    {
+        tmp32 |= (uint32_t)kRTC_LossOfClockInterruptEnable;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TIR_LCIE */
+#endif /* FSL_FEATURE_RTC_HAS_TIR */
+
+    return tmp32;
+}
+
+/*!
+ * brief Gets the RTC status flags.
+ *
+ * param base RTC peripheral base address
+ *
+ * return The status flags. This is the logical OR of members of the
+ *         enumeration ::rtc_status_flags_t
+ */
+uint32_t RTC_GetStatusFlags(RTC_Type *base)
+{
+    uint32_t tmp32 = 0U;
+
+    /* RTC_SR */
+    if (0U != (RTC_SR_TIF_MASK & base->SR))
+    {
+        tmp32 |= (uint32_t)kRTC_TimeInvalidFlag;
+    }
+    if (0U != (RTC_SR_TOF_MASK & base->SR))
+    {
+        tmp32 |= (uint32_t)kRTC_TimeOverflowFlag;
+    }
+    if (0U != (RTC_SR_TAF_MASK & base->SR))
+    {
+        tmp32 |= (uint32_t)kRTC_AlarmFlag;
+    }
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+    if (0U != (RTC_SR_MOF_MASK & base->SR))
+    {
+        tmp32 |= (uint32_t)kRTC_MonotonicOverflowFlag;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+#if (defined(FSL_FEATURE_RTC_HAS_SR_TIDF) && FSL_FEATURE_RTC_HAS_SR_TIDF)
+    if (0U != (RTC_SR_TIDF_MASK & base->SR))
+    {
+        tmp32 |= (uint32_t)kRTC_TamperInterruptDetectFlag;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_SR_TIDF */
+
+#if (defined(FSL_FEATURE_RTC_HAS_TDR) && FSL_FEATURE_RTC_HAS_TDR)
+    /* RTC_TDR */
+    if (0U != (RTC_TDR_TMF_MASK & base->TDR))
+    {
+        tmp32 |= (uint32_t)kRTC_TestModeFlag;
+    }
+    if (0U != (RTC_TDR_FSF_MASK & base->TDR))
+    {
+        tmp32 |= (uint32_t)kRTC_FlashSecurityFlag;
+    }
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_TPF) && FSL_FEATURE_RTC_HAS_TDR_TPF)
+    if (0U != (RTC_TDR_TPF_MASK & base->TDR))
+    {
+        tmp32 |= (uint32_t)kRTC_TamperPinFlag;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TDR_TPF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_STF) && FSL_FEATURE_RTC_HAS_TDR_STF)
+    if (0U != (RTC_TDR_STF_MASK & base->TDR))
+    {
+        tmp32 |= (uint32_t)kRTC_SecurityTamperFlag;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TDR_STF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_LCTF) && FSL_FEATURE_RTC_HAS_TDR_LCTF)
+    if (0U != (RTC_TDR_LCTF_MASK & base->TDR))
+    {
+        tmp32 |= (uint32_t)kRTC_LossOfClockTamperFlag;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TDR_LCTF */
+#endif /* FSL_FEATURE_RTC_HAS_TDR */
+
+    return tmp32;
+}
+
+/*!
+ * brief  Clears the RTC status flags.
+ *
+ * param base RTC peripheral base address
+ * param mask The status flags to clear. This is a logical OR of members of the
+ *             enumeration ::rtc_status_flags_t
+ */
+void RTC_ClearStatusFlags(RTC_Type *base, uint32_t mask)
+{
+    /* The alarm flag is cleared by writing to the TAR register */
+    if (0U != (mask & (uint32_t)kRTC_AlarmFlag))
+    {
+        base->TAR = 0U;
+    }
+
+    /* The timer overflow flag is cleared by initializing the TSR register.
+     * The time counter should be disabled for this write to be successful
+     */
+    if (0U != (mask & (uint32_t)kRTC_TimeOverflowFlag))
+    {
+        base->TSR = 1U;
+    }
+
+    /* The timer overflow flag is cleared by initializing the TSR register.
+     * The time counter should be disabled for this write to be successful
+     */
+    if (0U != (mask & (uint32_t)kRTC_TimeInvalidFlag))
+    {
+        base->TSR = 1U;
+    }
+
+#if (defined(FSL_FEATURE_RTC_HAS_TDR) && FSL_FEATURE_RTC_HAS_TDR)
+    /* To clear, write logic one to this flag after exiting from all test modes */
+    if (0U != ((uint32_t)kRTC_TestModeFlag & mask))
+    {
+        base->TDR = RTC_TDR_TMF_MASK;
+    }
+    /* To clear, write logic one to this flag after flash security is enabled */
+    if (0U != ((uint32_t)kRTC_FlashSecurityFlag & mask))
+    {
+        base->TDR = RTC_TDR_FSF_MASK;
+    }
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_TPF) && FSL_FEATURE_RTC_HAS_TDR_TPF)
+    /* To clear, write logic one to the corresponding flag after that tamper pin negates */
+    if (0U != ((uint32_t)kRTC_TamperPinFlag & mask))
+    {
+        base->TDR = RTC_TDR_TPF_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TDR_TPF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_STF) && FSL_FEATURE_RTC_HAS_TDR_STF)
+    /* To clear, write logic one to this flag after security module has negated its tamper detect */
+    if (0U != ((uint32_t)kRTC_SecurityTamperFlag & mask))
+    {
+        base->TDR = RTC_TDR_STF_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TDR_STF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_LCTF) && FSL_FEATURE_RTC_HAS_TDR_LCTF)
+    /* To clear, write logic one to this flag after loss of clock negates */
+    if (0U != ((uint32_t)kRTC_LossOfClockTamperFlag & mask))
+    {
+        base->TDR = RTC_TDR_LCTF_MASK;
+    }
+#endif /* FSL_FEATURE_RTC_HAS_TDR_LCTF */
+#endif /* FSL_FEATURE_RTC_HAS_TDR */
+}
+
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+
+/*!
+ * brief Reads the values of the Monotonic Counter High and Monotonic Counter Low and returns
+ *        them as a single value.
+ *
+ * param base    RTC peripheral base address
+ * param counter Pointer to variable where the value is stored.
+ */
+void RTC_GetMonotonicCounter(RTC_Type *base, uint64_t *counter)
+{
+    uint64_t u64temp;
+
+    assert(NULL != counter);
+
+    u64temp  = (uint64_t)base->MCLR;
+    *counter = (((uint64_t)base->MCHR << 32U) | u64temp);
+}
+
+/*!
+ * brief Writes values Monotonic Counter High and Monotonic Counter Low by decomposing
+ *        the given single value. The Monotonic Overflow Flag in RTC_SR is cleared due to the API.
+ *
+ * param base    RTC peripheral base address
+ * param counter Counter value
+ */
+void RTC_SetMonotonicCounter(RTC_Type *base, uint64_t counter)
+{
+    /* Prepare to initialize the register with the new value written */
+    base->MER &= ~RTC_MER_MCE_MASK;
+
+    base->MCHR = (uint32_t)((counter) >> 32);
+    base->MCLR = (uint32_t)(counter);
+}
+
+/*!
+ * brief Increments the Monotonic Counter by one.
+ *
+ * Increments the Monotonic Counter (registers RTC_MCLR and RTC_MCHR accordingly) by setting
+ * the monotonic counter enable (MER[MCE]) and then writing to the RTC_MCLR register. A write to the
+ * monotonic counter low that causes it to overflow also increments the monotonic counter high.
+ *
+ * param base RTC peripheral base address
+ *
+ * return kStatus_Success: success
+ *         kStatus_Fail: error occurred, either time invalid or monotonic overflow flag was found
+ */
+status_t RTC_IncrementMonotonicCounter(RTC_Type *base)
+{
+    if (0U != (base->SR & (RTC_SR_MOF_MASK | RTC_SR_TIF_MASK)))
+    {
+        return kStatus_Fail;
+    }
+
+    /* Prepare to switch to increment mode */
+    base->MER |= RTC_MER_MCE_MASK;
+    /* Write anything so the counter increments*/
+    base->MCLR = 1U;
+
+    return kStatus_Success;
+}
+
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */

--- a/drivers/fsl_rtc.c
+++ b/drivers/fsl_rtc.c
@@ -36,22 +36,22 @@
  */
 static bool RTC_CheckDatetimeFormat(const rtc_datetime_t *datetime);
 
-/*!
- * @brief Converts time data from datetime to seconds
- *
- * @param datetime Pointer to datetime structure where the date and time details are stored
- *
- * @return The result of the conversion in seconds
- */
-static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime);
-
-/*!
- * @brief Converts time data from seconds to a datetime structure
- *
- * @param seconds  Seconds value that needs to be converted to datetime format
- * @param datetime Pointer to the datetime structure where the result of the conversion is stored
- */
-static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime);
+///*!
+// * @brief Converts time data from datetime to seconds
+// *
+// * @param datetime Pointer to datetime structure where the date and time details are stored
+// *
+// * @return The result of the conversion in seconds
+// */
+//static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime);
+//
+///*!
+// * @brief Converts time data from seconds to a datetime structure
+// *
+// * @param seconds  Seconds value that needs to be converted to datetime format
+// * @param datetime Pointer to the datetime structure where the result of the conversion is stored
+// */
+//static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime);
 
 /*******************************************************************************
  * Code
@@ -88,7 +88,7 @@ static bool RTC_CheckDatetimeFormat(const rtc_datetime_t *datetime)
     return true;
 }
 
-static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime)
+uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime)
 {
     assert(NULL != datetime);
 
@@ -118,7 +118,7 @@ static uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime)
     return seconds;
 }
 
-static void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime)
+void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime)
 {
     assert(NULL != datetime);
 

--- a/drivers/fsl_rtc.h
+++ b/drivers/fsl_rtc.h
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _FSL_RTC_H_
+#define _FSL_RTC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup rtc
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*@{*/
+#define FSL_RTC_DRIVER_VERSION (MAKE_VERSION(2, 2, 1)) /*!< Version 2.2.1 */
+/*@}*/
+
+/*! @brief List of RTC interrupts */
+typedef enum _rtc_interrupt_enable
+{
+    kRTC_TimeInvalidInterruptEnable  = (1U << 0U), /*!< Time invalid interrupt.*/
+    kRTC_TimeOverflowInterruptEnable = (1U << 1U), /*!< Time overflow interrupt.*/
+    kRTC_AlarmInterruptEnable        = (1U << 2U), /*!< Alarm interrupt.*/
+    kRTC_SecondsInterruptEnable      = (1U << 3U), /*!< Seconds interrupt.*/
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+    kRTC_MonotonicOverflowInterruptEnable = (1U << 4U), /*!< Monotonic Overflow Interrupt Enable */
+#endif                                                  /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR) && FSL_FEATURE_RTC_HAS_TIR)
+    kRTC_TestModeInterruptEnable      = (1U << 5U), /* test mode interrupt */
+    kRTC_FlashSecurityInterruptEnable = (1U << 6U), /* flash security interrupt */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_TPIE) && FSL_FEATURE_RTC_HAS_TIR_TPIE)
+    kRTC_TamperPinInterruptEnable = (1U << 7U), /* Tamper pin interrupt */
+#endif                                          /* FSL_FEATURE_RTC_HAS_TIR_TPIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_SIE) && FSL_FEATURE_RTC_HAS_TIR_SIE)
+    kRTC_SecurityModuleInterruptEnable = (1U << 8U), /* security module interrupt */
+#endif                                               /* FSL_FEATURE_RTC_HAS_TIR_SIE */
+#if (defined(FSL_FEATURE_RTC_HAS_TIR_LCIE) && FSL_FEATURE_RTC_HAS_TIR_LCIE)
+    kRTC_LossOfClockInterruptEnable = (1U << 9U), /* loss of clock interrupt */
+#endif                                            /* FSL_FEATURE_RTC_HAS_TIR_LCIE */
+#endif                                            /* FSL_FEATURE_RTC_HAS_TIR */
+} rtc_interrupt_enable_t;
+
+/*! @brief List of RTC flags */
+typedef enum _rtc_status_flags
+{
+    kRTC_TimeInvalidFlag  = (1U << 0U), /*!< Time invalid flag */
+    kRTC_TimeOverflowFlag = (1U << 1U), /*!< Time overflow flag */
+    kRTC_AlarmFlag        = (1U << 2U), /*!< Alarm flag*/
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+    kRTC_MonotonicOverflowFlag = (1U << 3U), /*!< Monotonic Overflow Flag */
+#endif                                       /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+#if (defined(FSL_FEATURE_RTC_HAS_SR_TIDF) && FSL_FEATURE_RTC_HAS_SR_TIDF)
+    kRTC_TamperInterruptDetectFlag = (1U << 4U), /*!< Tamper interrupt detect flag */
+#endif                                           /* FSL_FEATURE_RTC_HAS_SR_TIDF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR) && FSL_FEATURE_RTC_HAS_TDR)
+    kRTC_TestModeFlag      = (1U << 5U), /* Test mode flag */
+    kRTC_FlashSecurityFlag = (1U << 6U), /* Flash security flag */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_TPF) && FSL_FEATURE_RTC_HAS_TDR_TPF)
+    kRTC_TamperPinFlag = (1U << 7U), /* Tamper pin flag */
+#endif                               /* FSL_FEATURE_RTC_HAS_TDR_TPF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_STF) && FSL_FEATURE_RTC_HAS_TDR_STF)
+    kRTC_SecurityTamperFlag = (1U << 8U), /* Security tamper flag */
+#endif                                    /* FSL_FEATURE_RTC_HAS_TDR_STF */
+#if (defined(FSL_FEATURE_RTC_HAS_TDR_LCTF) && FSL_FEATURE_RTC_HAS_TDR_LCTF)
+    kRTC_LossOfClockTamperFlag = (1U << 9U), /* Loss of clock flag */
+#endif                                       /* FSL_FEATURE_RTC_HAS_TDR_LCTF */
+#endif                                       /* FSL_FEATURE_RTC_HAS_TDR */
+} rtc_status_flags_t;
+
+#if (defined(FSL_FEATURE_RTC_HAS_OSC_SCXP) && FSL_FEATURE_RTC_HAS_OSC_SCXP)
+
+/*! @brief List of RTC Oscillator capacitor load settings */
+typedef enum _rtc_osc_cap_load
+{
+    kRTC_Capacitor_2p  = RTC_CR_SC2P_MASK, /*!< 2 pF capacitor load */
+    kRTC_Capacitor_4p  = RTC_CR_SC4P_MASK, /*!< 4 pF capacitor load */
+    kRTC_Capacitor_8p  = RTC_CR_SC8P_MASK, /*!< 8 pF capacitor load */
+    kRTC_Capacitor_16p = RTC_CR_SC16P_MASK /*!< 16 pF capacitor load */
+} rtc_osc_cap_load_t;
+
+#endif /* FSL_FEATURE_SCG_HAS_OSC_SCXP */
+
+/*! @brief Structure is used to hold the date and time */
+typedef struct _rtc_datetime
+{
+    uint16_t year;  /*!< Range from 1970 to 2099.*/
+    uint8_t month;  /*!< Range from 1 to 12.*/
+    uint8_t day;    /*!< Range from 1 to 31 (depending on month).*/
+    uint8_t hour;   /*!< Range from 0 to 23.*/
+    uint8_t minute; /*!< Range from 0 to 59.*/
+    uint8_t second; /*!< Range from 0 to 59.*/
+} rtc_datetime_t;
+
+#if (defined(FSL_FEATURE_RTC_HAS_PCR) && FSL_FEATURE_RTC_HAS_PCR)
+
+/*!
+ * @brief RTC pin config structure
+ */
+typedef struct _rtc_pin_config
+{
+    bool inputLogic;       /*!< true: Tamper pin input data is logic one.
+                                false: Tamper pin input data is logic zero. */
+    bool pinActiveLow;     /*!< true: Tamper pin is active low.
+                                false: Tamper pin is active high. */
+    bool filterEnable;     /*!< true: Input filter is enabled on the tamper pin.
+                                false: Input filter is disabled on the tamper pin. */
+    bool pullSelectNegate; /*!< true: Tamper pin pull resistor direction will negate the tamper pin.
+                                false: Tamper pin pull resistor direction will assert the tamper pin. */
+    bool pullEnable;       /*!< true: Pull resistor is enabled on tamper pin.
+                                false: Pull resistor is disabled on tamper pin. */
+} rtc_pin_config_t;
+
+#endif /* FSL_FEATURE_RTC_HAS_PCR */
+
+/*!
+ * @brief RTC config structure
+ *
+ * This structure holds the configuration settings for the RTC peripheral. To initialize this
+ * structure to reasonable defaults, call the RTC_GetDefaultConfig() function and pass a
+ * pointer to your config structure instance.
+ *
+ * The config struct can be made const so it resides in flash
+ */
+typedef struct _rtc_config
+{
+    bool wakeupSelect;             /*!< true: Wakeup pin outputs the 32 KHz clock;
+                                        false:Wakeup pin used to wakeup the chip  */
+    bool updateMode;               /*!< true: Registers can be written even when locked under certain
+                                        conditions, false: No writes allowed when registers are locked */
+    bool supervisorAccess;         /*!< true: Non-supervisor accesses are allowed;
+                                        false: Non-supervisor accesses are not supported */
+    uint32_t compensationInterval; /*!< Compensation interval that is written to the CIR field in RTC TCR Register */
+    uint32_t compensationTime;     /*!< Compensation time that is written to the TCR field in RTC TCR Register */
+} rtc_config_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Ungates the RTC clock and configures the peripheral for basic operation.
+ *
+ * This function issues a software reset if the timer invalid flag is set.
+ *
+ * @note This API should be called at the beginning of the application using the RTC driver.
+ *
+ * @param base   RTC peripheral base address
+ * @param config Pointer to the user's RTC configuration structure.
+ */
+void RTC_Init(RTC_Type *base, const rtc_config_t *config);
+
+/*!
+ * @brief Stops the timer and gate the RTC clock.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_Deinit(RTC_Type *base)
+{
+    /* Stop the RTC timer */
+    base->SR &= ~RTC_SR_TCE_MASK;
+
+#if defined(RTC_CLOCKS)
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Gate the module clock */
+    CLOCK_DisableClock(kCLOCK_Rtc0);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+#endif /* RTC_CLOCKS */
+}
+
+/*!
+ * @brief Fills in the RTC config struct with the default settings.
+ *
+ * The default values are as follows.
+ * @code
+ *    config->wakeupSelect = false;
+ *    config->updateMode = false;
+ *    config->supervisorAccess = false;
+ *    config->compensationInterval = 0;
+ *    config->compensationTime = 0;
+ * @endcode
+ * @param config Pointer to the user's RTC configuration structure.
+ */
+void RTC_GetDefaultConfig(rtc_config_t *config);
+
+/*! @}*/
+
+/*!
+ * @name Current Time & Alarm
+ * @{
+ */
+
+/*!
+ * @brief Sets the RTC date and time according to the given time structure.
+ *
+ * The RTC counter must be stopped prior to calling this function because writes to the RTC
+ * seconds register fail if the RTC counter is running.
+ *
+ * @param base     RTC peripheral base address
+ * @param datetime Pointer to the structure where the date and time details are stored.
+ *
+ * @return kStatus_Success: Success in setting the time and starting the RTC
+ *         kStatus_InvalidArgument: Error because the datetime format is incorrect
+ */
+status_t RTC_SetDatetime(RTC_Type *base, const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Gets the RTC time and stores it in the given time structure.
+ *
+ * @param base     RTC peripheral base address
+ * @param datetime Pointer to the structure where the date and time details are stored.
+ */
+void RTC_GetDatetime(RTC_Type *base, rtc_datetime_t *datetime);
+
+/*!
+ * @brief Sets the RTC alarm time.
+ *
+ * The function checks whether the specified alarm time is greater than the present
+ * time. If not, the function does not set the alarm and returns an error.
+ *
+ * @param base      RTC peripheral base address
+ * @param alarmTime Pointer to the structure where the alarm time is stored.
+ *
+ * @return kStatus_Success: success in setting the RTC alarm
+ *         kStatus_InvalidArgument: Error because the alarm datetime format is incorrect
+ *         kStatus_Fail: Error because the alarm time has already passed
+ */
+status_t RTC_SetAlarm(RTC_Type *base, const rtc_datetime_t *alarmTime);
+
+/*!
+ * @brief Returns the RTC alarm time.
+ *
+ * @param base     RTC peripheral base address
+ * @param datetime Pointer to the structure where the alarm date and time details are stored.
+ */
+void RTC_GetAlarm(RTC_Type *base, rtc_datetime_t *datetime);
+
+/*! @}*/
+
+/*!
+ * @name Interrupt Interface
+ * @{
+ */
+
+/*!
+ * @brief Enables the selected RTC interrupts.
+ *
+ * @param base RTC peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::rtc_interrupt_enable_t
+ */
+void RTC_EnableInterrupts(RTC_Type *base, uint32_t mask);
+
+/*!
+ * @brief Disables the selected RTC interrupts.
+ *
+ * @param base RTC peripheral base address
+ * @param mask The interrupts to enable. This is a logical OR of members of the
+ *             enumeration ::rtc_interrupt_enable_t
+ */
+void RTC_DisableInterrupts(RTC_Type *base, uint32_t mask);
+
+/*!
+ * @brief Gets the enabled RTC interrupts.
+ *
+ * @param base RTC peripheral base address
+ *
+ * @return The enabled interrupts. This is the logical OR of members of the
+ *         enumeration ::rtc_interrupt_enable_t
+ */
+uint32_t RTC_GetEnabledInterrupts(RTC_Type *base);
+
+/*! @}*/
+
+/*!
+ * @name Status Interface
+ * @{
+ */
+
+/*!
+ * @brief Gets the RTC status flags.
+ *
+ * @param base RTC peripheral base address
+ *
+ * @return The status flags. This is the logical OR of members of the
+ *         enumeration ::rtc_status_flags_t
+ */
+uint32_t RTC_GetStatusFlags(RTC_Type *base);
+
+/*!
+ * @brief  Clears the RTC status flags.
+ *
+ * @param base RTC peripheral base address
+ * @param mask The status flags to clear. This is a logical OR of members of the
+ *             enumeration ::rtc_status_flags_t
+ */
+void RTC_ClearStatusFlags(RTC_Type *base, uint32_t mask);
+
+/*! @}*/
+
+#if !(defined(FSL_FEATURE_RTC_HAS_NO_CR_OSCE) && FSL_FEATURE_RTC_HAS_NO_CR_OSCE)
+/*!
+ * @brief Set RTC clock source.
+ *
+ * @param base RTC peripheral base address
+ *
+ * @note After setting this bit, wait the oscillator startup time before enabling
+ *       the time counter to allow the 32.768 kHz clock time to stabilize.
+ */
+static inline void RTC_SetClockSource(RTC_Type *base)
+{
+    /* Enable the RTC 32KHz oscillator */
+    base->CR |= RTC_CR_OSCE_MASK;
+}
+#endif /* FSL_FEATURE_RTC_HAS_NO_CR_OSCE */
+
+#if (defined(FSL_FEATURE_RTC_HAS_TTSR) && FSL_FEATURE_RTC_HAS_TTSR)
+
+/*!
+ * @brief Get the RTC tamper time seconds.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline uint32_t RTC_GetTamperTimeSeconds(RTC_Type *base)
+{
+    return base->TTSR;
+}
+
+#endif /* FSL_FEATURE_RTC_HAS_TTSR */
+
+/*!
+ * @name Timer Start and Stop
+ * @{
+ */
+
+/*!
+ * @brief Starts the RTC time counter.
+ *
+ * After calling this function, the timer counter increments once a second provided SR[TOF] or
+ * SR[TIF] are not set.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_StartTimer(RTC_Type *base)
+{
+    base->SR |= RTC_SR_TCE_MASK;
+}
+
+/*!
+ * @brief Stops the RTC time counter.
+ *
+ * RTC's seconds register can be written to only when the timer is stopped.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_StopTimer(RTC_Type *base)
+{
+    base->SR &= ~RTC_SR_TCE_MASK;
+}
+
+/*! @}*/
+
+#if (defined(FSL_FEATURE_RTC_HAS_OSC_SCXP) && FSL_FEATURE_RTC_HAS_OSC_SCXP)
+
+/*!
+ * @brief This function sets the specified capacitor configuration for the RTC oscillator.
+ *
+ * @param base    RTC peripheral base address
+ * @param capLoad Oscillator loads to enable. This is a logical OR of members of the
+ *                enumeration ::rtc_osc_cap_load_t
+ */
+static inline void RTC_SetOscCapLoad(RTC_Type *base, uint32_t capLoad)
+{
+    uint32_t reg = base->CR;
+
+    reg &= ~(RTC_CR_SC2P_MASK | RTC_CR_SC4P_MASK | RTC_CR_SC8P_MASK | RTC_CR_SC16P_MASK);
+    reg |= capLoad;
+
+    base->CR = reg;
+}
+
+#endif /* FSL_FEATURE_SCG_HAS_OSC_SCXP */
+
+/*!
+ * @brief Performs a software reset on the RTC module.
+ *
+ * This resets all RTC registers except for the SWR bit and the RTC_WAR and RTC_RAR
+ * registers. The SWR bit is cleared by software explicitly clearing it.
+ *
+ * @param base RTC peripheral base address
+ */
+static inline void RTC_Reset(RTC_Type *base)
+{
+    base->CR |= RTC_CR_SWR_MASK;
+    base->CR &= ~RTC_CR_SWR_MASK;
+
+    /* Set TSR register to 0x1 to avoid the timer invalid (TIF) bit being set in the SR register */
+    base->TSR = 1U;
+}
+
+#if defined(FSL_FEATURE_RTC_HAS_MONOTONIC) && (FSL_FEATURE_RTC_HAS_MONOTONIC)
+
+/*!
+ * @name Monotonic counter functions
+ * @{
+ */
+
+/*!
+ * @brief Reads the values of the Monotonic Counter High and Monotonic Counter Low and returns
+ *        them as a single value.
+ *
+ * @param base    RTC peripheral base address
+ * @param counter Pointer to variable where the value is stored.
+ */
+void RTC_GetMonotonicCounter(RTC_Type *base, uint64_t *counter);
+
+/*!
+ * @brief Writes values Monotonic Counter High and Monotonic Counter Low by decomposing
+ *        the given single value. The Monotonic Overflow Flag in RTC_SR is cleared due to the API.
+ *
+ * @param base    RTC peripheral base address
+ * @param counter Counter value
+ */
+void RTC_SetMonotonicCounter(RTC_Type *base, uint64_t counter);
+
+/*!
+ * @brief Increments the Monotonic Counter by one.
+ *
+ * Increments the Monotonic Counter (registers RTC_MCLR and RTC_MCHR accordingly) by setting
+ * the monotonic counter enable (MER[MCE]) and then writing to the RTC_MCLR register. A write to the
+ * monotonic counter low that causes it to overflow also increments the monotonic counter high.
+ *
+ * @param base RTC peripheral base address
+ *
+ * @return kStatus_Success: success
+ *         kStatus_Fail: error occurred, either time invalid or monotonic overflow flag was found
+ */
+status_t RTC_IncrementMonotonicCounter(RTC_Type *base);
+
+/*! @}*/
+
+#endif /* FSL_FEATURE_RTC_HAS_MONOTONIC */
+
+#if defined(FSL_FEATURE_RTC_HAS_WAKEUP_PIN) && (FSL_FEATURE_RTC_HAS_WAKEUP_PIN)
+/*!
+ * @brief Enables or disables the RTC Wakeup Pin Operation.
+ *
+ * This function enable or disable RTC Wakeup Pin.
+ * The wakeup pin is optional and not available on all devices.
+ *
+ * @param base RTC_Type base pointer.
+ * @param enable true to enable, false to disable.
+ */
+static inline void RTC_EnableWakeUpPin(RTC_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->CR |= RTC_CR_WPE_MASK;
+    }
+    else
+    {
+        base->CR &= ~RTC_CR_WPE_MASK;
+    }
+}
+#endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_RTC_H_ */

--- a/drivers/fsl_rtc.h
+++ b/drivers/fsl_rtc.h
@@ -208,6 +208,23 @@ void RTC_GetDefaultConfig(rtc_config_t *config);
  */
 
 /*!
+ * @brief Converts time data from datetime to seconds
+ *
+ * @param datetime Pointer to datetime structure where the date and time details are stored
+ *
+ * @return The result of the conversion in seconds
+ */
+uint32_t RTC_ConvertDatetimeToSeconds(const rtc_datetime_t *datetime);
+
+/*!
+ * @brief Converts time data from seconds to a datetime structure
+ *
+ * @param seconds  Seconds value that needs to be converted to datetime format
+ * @param datetime Pointer to the datetime structure where the result of the conversion is stored
+ */
+void RTC_ConvertSecondsToDatetime(uint32_t seconds, rtc_datetime_t *datetime);
+
+/*!
  * @brief Sets the RTC date and time according to the given time structure.
  *
  * The RTC counter must be stopped prior to calling this function because writes to the RTC

--- a/lwip/src/include/lwip/apps/sntp.h
+++ b/lwip/src/include/lwip/apps/sntp.h
@@ -49,8 +49,6 @@ extern "C" {
 #define SNTP_OPMODE_POLL            0
 #define SNTP_OPMODE_LISTENONLY      1
 
-extern time_t global_time;
-
 void sntp_setoperatingmode(u8_t operating_mode);
 u8_t sntp_getoperatingmode(void);
 

--- a/source/eink_control.c
+++ b/source/eink_control.c
@@ -334,10 +334,16 @@ void einkDisplayFrameFromBufferBlocking(const unsigned char* frame_buffer_black,
 /**
  * @brief: This displays the frame data from SRAM
  */
-void einkDisplayFrameFromSRAM() {
+void einkDisplayFrameFromSRAMBlocking() {
 
 	einkSendCommand(DISPLAY_REFRESH);
 	einkWaitUntilIdle();
+
+}
+
+void einkDisplayFrameFromSRAMNonBlocking() {
+
+	einkSendCommand(DISPLAY_REFRESH);
 
 }
 

--- a/source/eink_control.c
+++ b/source/eink_control.c
@@ -188,7 +188,7 @@ void einkWaitUntilIdle() {
 	while(isBusy) {
 
 		isBusy = !GPIO_PinRead(BOARD_INITPINS_BUSY_GPIO, BOARD_INITPINS_BUSY_PIN);
-		//SysTick_DelayTicks(100U);
+		SysTick_DelayTicks(100U);
 
 	}
 }
@@ -238,17 +238,17 @@ void einkClearFrame() {
 	einkSendData(EPD_HEIGHT & 0xff);         //264
 
 	einkSendCommand(DATA_START_TRANSMISSION_1);
-	//SysTick_DelayTicks(2U);
+	SysTick_DelayTicks(2U);
 	for(i = 0; i < EPD_WIDTH * EPD_HEIGHT / 8; i++) {
 		einkSendData(0x00);
 	}
-	//SysTick_DelayTicks(2);
+	SysTick_DelayTicks(2);
 	einkSendCommand(DATA_START_TRANSMISSION_2);
-	//SysTick_DelayTicks(2);
+	SysTick_DelayTicks(2);
 	for(i = 0; i < EPD_WIDTH * EPD_HEIGHT / 8; i++) {
 		einkSendData(0x00);
 	}
-	//SysTick_DelayTicks(2);
+	SysTick_DelayTicks(2);
 }
 
 /**
@@ -273,20 +273,20 @@ int einkDisplayFrameFromBufferNonBlocking(const unsigned char* frame_buffer_blac
 
     if (frame_buffer_black != NULL) {
         einkSendCommand(DATA_START_TRANSMISSION_1);
-        //SysTick_DelayTicks(2U);
+        SysTick_DelayTicks(2U);
         for(i = 0; i < EPD_WIDTH * EPD_HEIGHT / 8; i++) {
             einkSendData(pgm_read_byte(&frame_buffer_black[i]));
             //PRINTF("%x ", pgm_read_byte(&frame_buffer_black[i]));
         }
-        //SysTick_DelayTicks(2U);
+        SysTick_DelayTicks(2U);
     }
     if (frame_buffer_red != NULL) {
         einkSendCommand(DATA_START_TRANSMISSION_2);
-        //SysTick_DelayTicks(2U);
+        SysTick_DelayTicks(2U);
         for(i = 0; i < EPD_WIDTH * EPD_HEIGHT / 8; i++) {
             einkSendData(pgm_read_byte(&frame_buffer_red[i]));
         }
-        //SysTick_DelayTicks(2U);
+        SysTick_DelayTicks(2U);
     }
     einkSendCommand(DISPLAY_REFRESH);
 

--- a/source/eink_control.h
+++ b/source/eink_control.h
@@ -73,7 +73,8 @@ void einkClearFrame();
 void einkDisplayFrameFromBufferBlocking(const unsigned char* frame_buffer_black, const unsigned char* frame_buffer_red);
 int  einkDisplayFrameFromBufferNonBlocking(const unsigned char* frame_buffer_black, const unsigned char* frame_buffer_red);
 
-void einkDisplayFrameFromSRAM();
+void einkDisplayFrameFromSRAMBlocking();
+void einkDisplayFrameFromSRAMNonBlocking();
 
 // Paint functions, for modifying the image buffer before passing it through SPI
 void paintClear(unsigned char* image, int colored);


### PR DESCRIPTION
This frees up the general-purpose timer to be used for delays in e-paper code and elsewhere, while also eliminating the need to guess how long a screen refresh takes in order to keep accurate time.